### PR TITLE
Use more_itertools.collapse instead of iteration_utilities.deepflatten

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pytest = "*"
 twine = "*"
 
 [packages]
-iteration_utilities = "*"
+more-itertools = "*"
 
 [requires]
 python_version = "3.8"

--- a/htbuilder/__init__.py
+++ b/htbuilder/__init__.py
@@ -59,38 +59,39 @@ If using Python < 3.7, the import should look like this instead:
 
 """
 
+from more_itertools import collapse
+
 from .funcs import func
 from .units import unit
-from .utils import classes, styles, fonts, rule
-from iteration_utilities import deepflatten
+from .utils import classes, fonts, rule, styles
 
-
-EMPTY_ELEMENTS = set([
-    # https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
-    "area",
-    "base",
-    "br",
-    "col",
-    "embed",
-    "hr",
-    "img",
-    "input",
-    "keygen",
-    "link",
-    "meta",
-    "param",
-    "source",
-    "track",
-    "wbr",
-
-    # SVG
-    "circle",
-    "line",
-    "path",
-    "polygon",
-    "polyline",
-    "rect",
-])
+EMPTY_ELEMENTS = set(
+    [
+        # https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "keygen",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+        # SVG
+        "circle",
+        "line",
+        "path",
+        "polygon",
+        "polyline",
+        "rect",
+    ]
+)
 
 
 class _ElementCreator(object):
@@ -121,7 +122,7 @@ class HtmlElement(object):
         if children:
             if self._is_empty:
                 raise TypeError("<%s> cannot have children" % self._tag)
-            self._children = list(deepflatten([*self._children, *children]))
+            self._children = list(collapse([*self._children, *children]))
 
         if attrs:
             self._attrs = {**self._attrs, **attrs}
@@ -145,11 +146,10 @@ class HtmlElement(object):
     def __str__(self):
         args = {
             "tag": _clean_name(self._tag),
-            "attrs": " ".join([
-                "%s=\"%s\"" % (_clean_name(k), v)
-                for k, v in self._attrs.items()
-            ]),
-            "children": "".join([str(c) for c in self._children])
+            "attrs": " ".join(
+                ['%s="%s"' % (_clean_name(k), v) for k, v in self._attrs.items()]
+            ),
+            "children": "".join([str(c) for c in self._children]),
         }
 
         if self._is_empty:
@@ -171,7 +171,7 @@ def _clean_name(k):
 
 
 def fragment(*args):
-    return ''.join(str(arg) for arg in args)
+    return "".join(str(arg) for arg in args)
 
 
 # Python >= 3.7

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/tvst/htbuilder",
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
-    install_requires=[],
+    install_requires=["more-itertools"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import setuptools
 
-with open("README.md", "r", encoding='utf8') as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="htbuilder",
-    version="0.6.0",
+    version="0.6.1",
     author="Thiago Teixeira",
     author_email="me@thiagot.com",
     description="A purely-functional HTML builder for Python. Think JSX rather than templates.",
@@ -14,11 +14,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/tvst/htbuilder",
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
-    install_requires=["iteration_utilities"],
+    install_requires=[],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.5',
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
iteration_utilities only supports up to python 3.9, and causes some [issues](https://discuss.streamlit.io/t/how-to-hide-all-pages-before-login/32508/11?u=blackary) when installing on windows.

Also, bump the version number so we can get a release with the utf-8 fix for windows users.